### PR TITLE
Add exec-env to define WASI_SDK_PATH

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# WASI_SDK_PATH
+if [ -n "$ASDF_INSTALL_PATH" ]; then
+  if [ -z "$WASI_SDK_PATH" ]; then
+    export WASI_SDK_PATH="${ASDF_INSTALL_PATH}/wasi-sdk"
+  fi
+fi


### PR DESCRIPTION
Not entirely sure if this is done correctly, but it does define `WASI_SDK_PATH` when running a command through the plugin.

RE #1